### PR TITLE
Fix problems serializing ProjectInfo for a project with no files

### DIFF
--- a/src/Crowdin.Api/Typed/ProjectInfo.cs
+++ b/src/Crowdin.Api/Typed/ProjectInfo.cs
@@ -32,7 +32,9 @@ namespace Crowdin.Api.Typed
 
         public Int32 TotalStringsCount { get; private set; }
 
-        public Int32 TotalWordsCount { get; private set; }
+        /// <summary/>
+        /// <remarks>Projects with no files return an empty total_words_count element from api version 1</remarks>
+        public Int32? TotalWordsCount { get; private set; }
 
         public Int32 DuplicateStringsCount { get; private set; }
 
@@ -73,7 +75,7 @@ namespace Crowdin.Api.Typed
             ParticipantsCount = reader.ReadRequiredSiblingElementContentAsInt("participants_count");
             LogoUrl = reader.ReadRequiredSiblingElementContentAsUri("logo_url");
             TotalStringsCount = reader.ReadRequiredSiblingElementContentAsInt("total_strings_count");
-            TotalWordsCount = reader.ReadRequiredSiblingElementContentAsInt("total_words_count");
+            TotalWordsCount = reader.ReadOptionalSiblingElementContentAsInt("total_words_count");
             DuplicateStringsCount = reader.ReadRequiredSiblingElementContentAsInt("duplicate_strings_count");
             DuplicateWordsCount = reader.ReadRequiredSiblingElementContentAsInt("duplicate_words_count");
             InviteUrls = reader.ReadRequiredSiblingElementSubtreeAsObject<ProjectInviteUrls>("invite_url");

--- a/src/Crowdin.Api/Typed/XmlReaderExtensions.cs
+++ b/src/Crowdin.Api/Typed/XmlReaderExtensions.cs
@@ -129,7 +129,10 @@ namespace Crowdin.Api.Typed
         public static IEnumerable<T> ReadRequiredSiblingElementSubtreeAsCollection<T>(this XmlReader reader, String elementName, String itemElementName, Func<XmlReader, T> deserializer)
         {
             reader.ReadToNextRequiredSibling(elementName);
+            var isEmptyElement = reader.IsEmptyElement;
             reader.ReadStartElement();
+            if(isEmptyElement) // There are no child elements of elementName so return an empty IEnumerable
+                yield break;
             while (reader.ReadToNextSibling(itemElementName))
             {
                 using (XmlReader itemReader = reader.ReadSubtree())


### PR DESCRIPTION
* Skip reading to next sibling on empty elements so that <file/>
  doesn't result in reading to the end of the response xml
* Make TotalWordsCount optional since that is the way the api responds
  when there are no files. (Might be considered a bug in the Crowdin api)