### PR TITLE
Abstract File Parameters

### DIFF
--- a/src/Crowdin.Api/Typed/AddFileParameters.cs
+++ b/src/Crowdin.Api/Typed/AddFileParameters.cs
@@ -1,31 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using Crowdin.Api.Protocol;
 
 namespace Crowdin.Api.Typed
 {
-    public sealed class AddFileParameters
+    public sealed class AddFileParameters : FileParameters
     {
-        [Required]
-        public IDictionary<String, FileInfo> Files { get; set; }
-
-        public IDictionary<String, String> Titles { get; set; }
-
-        [Property("export_patterns")]
-        public IDictionary<String, String> ExportPatterns { get; set; }
-
-        public String Type { get; set; }
-
-        [Property("first_line_contains_header")]
-        public Boolean? FirstLineContainsHeader { get; set; }
-
         [Property("import_translations")]
         public Boolean? ImportTranslations { get; set; }
-
-        public String Scheme { get; set; }
-
-        public String Branch { get; set; }
 
         [Property("translate_content")]
         public Boolean? TranslateContent { get; set; }

--- a/src/Crowdin.Api/Typed/FileParameters.cs
+++ b/src/Crowdin.Api/Typed/FileParameters.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Crowdin.Api.Protocol;
+
+namespace Crowdin.Api.Typed
+{
+	public abstract class FileParameters
+	{
+		[Required]
+		public IDictionary<String, FileInfo> Files { get; set; }
+
+		public IDictionary<String, String> Titles { get; set; }
+
+		[Property("export_patterns")]
+		public IDictionary<String, String> ExportPatterns { get; set; }
+
+		public String Type { get; set; }
+
+		[Property("first_line_contains_header")]
+		public Boolean? FirstLineContainsHeader { get; set; }
+
+		public String Scheme { get; set; }
+
+		public String Branch { get; set; }
+	}
+}

--- a/src/Crowdin.Api/Typed/UpdateFileParameters.cs
+++ b/src/Crowdin.Api/Typed/UpdateFileParameters.cs
@@ -1,33 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using Crowdin.Api.Protocol;
 
 namespace Crowdin.Api.Typed
 {
-    public sealed class UpdateFileParameters
+    public sealed class UpdateFileParameters : FileParameters
     {
-        [Required]
-        public IDictionary<String, FileInfo> Files { get; set; }
-
-        public IDictionary<String, String> Titles { get; set; }
-
-        [Property("export_patterns")]
-        public IDictionary<String, String> ExportPatterns { get; set; }
-
         [Property("new_names")]
         public IDictionary<String, String> NewNames { get; set; }
 
-        public String Type { get; set; }
-
-        [Property("first_line_contains_header")]
-        public Boolean? FirstLineContainsHeader { get; set; }
-
-        public String Scheme { get; set; }
-
         [Property("update_option")]
         public UpdateFileOption? UpdateOption { get; set; }
-
-        public String Branch { get; set; }
     }
 }


### PR DESCRIPTION
Make AddFileParameters and UpdateFileParameters inherit from a new, abstract class

This will allow client code to abstract processing of configuration files for both adding and updating files, reducing the need for boilerplate code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crowdin/crowdin-dotnet-client/12)
<!-- Reviewable:end -->
